### PR TITLE
Replace deprecated pkg_resources with importlib.metadata for Python 3.13 compatibility

### DIFF
--- a/appmonitor_client/management/commands/appmonitor_check.py
+++ b/appmonitor_client/management/commands/appmonitor_check.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import requests, json, os 
 import platform
 import django
-import pkg_resources
+import importlib.metadata
 import decouple
 import sys
 
@@ -51,8 +51,10 @@ class Command(BaseCommand):
             platform_obj["system_info"]["django_version"] = django.get_version()
 
             # Build a list of installed python packages
-            installed_packages = pkg_resources.working_set
-            installed_packages_list = sorted(["%s==%s" % (i.key, i.version) for i in installed_packages])
+            installed_packages_list = sorted([
+                "%s==%s" % (dist.metadata["Name"], dist.metadata["Version"])
+                for dist in importlib.metadata.distributions()
+            ])
             platform_obj["python_packages"] = installed_packages_list
 
             url = APP_MONITOR_URL+'/api/update-platform-information/'


### PR DESCRIPTION
Replace deprecated pkg_resources with importlib.metadata for Python 3.13 compatibility